### PR TITLE
FIX: lib.js does not exist

### DIFF
--- a/module.json
+++ b/module.json
@@ -25,9 +25,6 @@
   "esmodules": [
     "scripts/module.js"
   ],
-  "scripts": [
-    "scripts/lib/lib.js"
-  ],
   "styles": [
     "styles/module.css"
   ],


### PR DESCRIPTION
This fixes an issue preventing installation. Tested against the latest V10 release.