### PR TITLE
add endpoint port

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -32,7 +32,6 @@ class S3Utils {
         
         if(game.settings.get(this.ID, this.SETTINGS.CUSTOM_STYLE)){
             game.data.files.s3.endpoint.hostname = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
-            game.data.files.s3.endpoint.port = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX); // No idea what this does, truth be told.
             game.data.files.s3.endpoint.host = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
             game.data.files.s3.endpoint.href = game.data.files.s3.endpoint.protocol + "//" + game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
         }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -32,6 +32,7 @@ class S3Utils {
         
         if(game.settings.get(this.ID, this.SETTINGS.CUSTOM_STYLE)){
             game.data.files.s3.endpoint.hostname = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
+            game.data.files.s3.endpoint.port = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
             game.data.files.s3.endpoint.host = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
             game.data.files.s3.endpoint.href = game.data.files.s3.endpoint.protocol + "//" + game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
         }
@@ -156,6 +157,12 @@ class S3Utils {
             game.data.files.s3.endpoint.protocol + 
             "//" + 
             game.data.files.s3.endpoint.hostname + 
+            ((game.data.files.s3.endpoint.port === 80) ? "" : ((game.data.files.s3.endpoint.port === 443) ? "" : ":" + game.data.files.s3.endpoint.port)) +
+                /* Add port number only if endpoint port isn't 80 or 443.
+                   Tested & verified to work on an endpoint port that ISN'T 80 or 443,
+                   but unsure how this logic holds up if given an endpoint URI without port.
+                   Also unsure if AWS SDK assumes the port in the endpoint object based on protocol.
+                   TL;DR Needs testing. */
             "/" +
             bucket +
             "/" +

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -32,7 +32,7 @@ class S3Utils {
         
         if(game.settings.get(this.ID, this.SETTINGS.CUSTOM_STYLE)){
             game.data.files.s3.endpoint.hostname = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
-            game.data.files.s3.endpoint.port = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
+            game.data.files.s3.endpoint.port = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX); // No idea what this does, truth be told.
             game.data.files.s3.endpoint.host = game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
             game.data.files.s3.endpoint.href = game.data.files.s3.endpoint.protocol + "//" + game.settings.get(this.ID, this.SETTINGS.CUSTOM_PREFIX);
         }


### PR DESCRIPTION
Hello!

To start with, apologies for the messy code, I am not particularly well versed in JavaScript. I use the [SeaweedFS](https://github.com/seaweedfs/seaweedfs) S3 server on a non-standard port, which was not acknowledged by neither this module nor foundry. The code in this MR is my messy patch that enabled my SeaweedFS S3 server to work. Thank you for your work on the module originally, I wouldn't be able to use my S3 server on Foundry without this!